### PR TITLE
fix(ghpage): add relative liquid filter to criteria subdir

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,8 @@ plugins:
   - jekyll-sitemap
 
 remote_theme: publiccodenet/jekyll-theme
+baseurl: /standard-for-public-code
+
 include:
   - "README.md"
   - "CONTRIBUTING.md"

--- a/criteria/index.md
+++ b/criteria/index.md
@@ -9,4 +9,4 @@ order: 0
 
 {% for page in sorted %}{% if page.dir == "/criteria/" %}{% if page.name != "index.md" %}{% if page.title %}
 
-1. [{{page.title}}]({{page.url}}){% endif%}    {% endif%}  {% endif%}{% endfor %}
+1. [{{page.title}}]({{page.url | relative_url}}){% endif%}    {% endif%}  {% endif%}{% endfor %}

--- a/index.md
+++ b/index.md
@@ -24,8 +24,8 @@ Additional context and background can be found in the [foreword](foreword.md).
 
 * [Readers guide: how to interpret this standard](readers-guide.md)
 * [Glossary](glossary.md)
-* [Criteria](criteria/){% assign sorted = site.pages | sort:"order" %}{% for page in sorted %}{% if page.dir == "/criteria/" %}{% if page.name != "index.md" %}{% if page.title %}
-  * [{{page.title}}]({{page.url}}){% endif%}{% endif%}{% endif%}{% endfor %}
+* [Criteria](criteria/){% assign sorted = site.pages |  sort:"order" %}{% for page in sorted %}{% if page.dir == "/criteria/" %}{% if page.name != "index.md" %}{% if page.title %}
+  * [{{page.title}}]({{page.url | relative_url}}){% endif%}{% endif%}{% endif%}{% endfor %}
 * [Authors](AUTHORS.md)
 * [Contributing guide](CONTRIBUTING.md)
 * [Code of conduct](CODE_OF_CONDUCT.md)

--- a/jargon.txt
+++ b/jargon.txt
@@ -13,6 +13,7 @@ AUAS
 authorsFile
 availableLanguages
 Barberi
+baseurl
 biotop
 bmpn
 BPMN

--- a/script/test-without-link-check.sh
+++ b/script/test-without-link-check.sh
@@ -15,11 +15,11 @@ set -e # halt script on error
 # (jekyll defaults to "origin" if a remote of that name exists,
 # which makes sense for a true fork, but not for most contributors)
 if [ "_${PAGES_REPO_NWO}_" == "__" ]; then
-export PAGES_REPO_NWO=standard-for-public-code/standard-for-public-code
+	export PAGES_REPO_NWO=standard-for-public-code/standard-for-public-code
 fi
 
 # Build the site
-bundle exec jekyll build
+bundle exec jekyll build -b ''
 
 # Check for broken links and missing alt tags:
 # jekyll does not require extentions like HTML
@@ -28,6 +28,6 @@ bundle exec jekyll build
 # ignore request rate limit errors (HTTP 429)
 # using the files in Jekylls build folder
 bundle exec htmlproofer \
-    --assume-extension \
-    --disable-external \
-    ./_site
+	--assume-extension \
+	--disable-external \
+	./_site


### PR DESCRIPTION
This adds a baseurl and liquid filter for relative urls which makes the criteria links work again.  
Note: I deployed this pr-branch so you can test.

Fixes #1036 