### PR TITLE
replace "tech debt" with "long-term maintainability"

### DIFF
--- a/criteria/make-the-codebase-reusable-and-portable.md
+++ b/criteria/make-the-codebase-reusable-and-portable.md
@@ -53,7 +53,7 @@ Source code which does not rely on the situation-specific infrastructure of any 
 
 ## Managers: what you need to do
 
-* Make sure that stakeholders and business owners understand that reusability is an explicit codebase goal as this reduces technical debt and provides sustainability for the codebase.
+* Make sure that stakeholders and business owners understand that reusability is an explicit codebase goal, as this improves long-term maintainability and provides sustainability for the codebase.
 * Make sure that your teams are collaborating with other teams.
 
 ## Developers and designers: what you need to do

--- a/foreword.md
+++ b/foreword.md
@@ -93,7 +93,7 @@ Being open unlocks many other things.
 
 Local responsibility and democratic accountability are ensured when a public organization implements and maintains their own public code.
 By being open and with a broader contributor base, the software is more secure as it benefits from many eyes spotting potential flaws.
-Many contributors share the maintenance work to keep it functional and modern, which reduces future technical debt.
+Many contributors share the maintenance work to keep it functional and modern, which improves long-term maintainability.
 The shared workload is more sustainable now and in the future.
 Its openness makes both the code and its data more easily adaptable in the future.
 The code will be easier to retool, repurpose or retire.


### PR DESCRIPTION
The use of the jargon term "technical debt" can be avoided. This is more clear English, and easier to translate.

See also:

https://github.com/standard-for-public-code/community-translations-standard/issues/48

 reported by @jgroenen