### PR TITLE
Add further reading: developmentStatus in publiccode.yml

### DIFF
--- a/criteria/document-codebase-maturity.md
+++ b/criteria/document-codebase-maturity.md
@@ -46,5 +46,6 @@ Understanding how a codebase has evolved is key to understanding the codebase an
 
 * [Semantic Versioning Specification](https://semver.org/) used by many codebases to label versions.
 * [Software release life cycle](https://en.wikipedia.org/wiki/Software_release_life_cycle)
+* You can use the [Development Status key in the `publiccode.yml` standard](https://yml.publiccode.tools/schema.core.html).
 * [Service Design and Delivery Process](https://www.dta.gov.au/help-and-advice/build-and-improve-services/service-design-and-delivery-process) by the Australian Digital Transformation Agency.
 * [Service Manual on Agile Delivery](https://www.gov.uk/service-manual/agile-delivery) by the UK Government Digital Service.


### PR DESCRIPTION
In order to provide a standardised model for documenting codebase maturity the `publiccode.yml` standard has maturity levels built in.

Standardising on these levels seems like a good idea.

Alternatively these could be added as a 'for example' in the criteria as well.