### PR TITLE
Add Anton Wiklund (Arbetsförmedlingen) as steering team member.

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -33,6 +33,7 @@ The current team members are:
 - Josef Andersson (Digg)
 - [Matti Schneider](https://mattischneider.fr)
 - [Bastien Guerry](https://bzg.fr)
+- Anton Wiklund (Arbetsförmedlingen)
 
 Ideally, no single organization will employ a majority of the steering team.
 

--- a/jargon.txt
+++ b/jargon.txt
@@ -3,6 +3,7 @@ Ainali
 Algoritmeregister
 Andersson
 Aotearoa
+Arbetsförmedlingen
 Arial
 Arnout
 AUAS
@@ -191,6 +192,7 @@ Waal
 weasyprint
 whitepaper
 Wikidata
+Wiklund
 wordmark
 wordmarks
 yaml


### PR DESCRIPTION
At the Standard for Public Code call on the 27th of February, it was suggested by Maria Dalhage (Arbetsförmedlingen) to add [Anton Wiklund (Arbetsförmedlingen)](https://github.com/ixuz) as a maintainer/member for Standard for Public Code.

As per recommendation from the team, I've opened this PR accordingly to the governance guidelines.