### PR TITLE
fix checklist criteria links, and a few others

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This means we need a new way of designing, developing and procuring both the sou
 
 This standard sets a quality level for codebases that meets the needs of public organizations, institutions and administrations as well as other critical infrastructural services.
 
-The standard lives at [standard-for-public-code.github.io/standard-for-public-code/](https://standard-for-public-code.github.io/standard-for-public-code/).
+The standard lives at [www.standardforpubliccode.org/](https://www.standardforpubliccode.org/).
 See [`index.md`](index.md) for an overview of all content.
 
 ## Help improve this standard
@@ -56,7 +56,7 @@ Please be lovely to all other community members.
 
 ## Preview, build and deploy
 
-The repository builds to a static site deployed at [standard-for-public-code.github.io/standard-for-public-code/](https://standard-for-public-code.github.io/standard-for-public-code/).
+The repository builds to a static site deployed at [www.standardforpubliccode.org/](https://www.standardforpubliccode.org/).
 It is built with [GitHub pages](https://pages.github.com) and [Jekyll](https://jekyllrb.com/).
 
 The content is made to be built with [Jekyll](http://jekyllrb.com/), which means you will need ruby and ruby-bundler installed, for example:

--- a/docs/standard-for-public-code.html
+++ b/docs/standard-for-public-code.html
@@ -51,7 +51,7 @@ The Standard for Public Code is not a codebase created in the context of a polic
 
 Link to commitment to meet the Standard for Public Code: [CONTRIBUTING.md](../CONTRIBUTING.md#1-make-your-changes)
 
-<h2><a href="https://standard-for-public-code.github.io/standard-for-public-code/criteria/code-in-the-open.html">Code in the open</a></h2>
+<h2><a href="https://www.standardforpubliccode.org/criteria/code-in-the-open.html">Code in the open</a></h2>
 
 &#9745;<!-- &#9745; --> criterion met.
 
@@ -119,7 +119,7 @@ Documenting which source code or policy underpins any specific interaction the g
 
 </table>
 
-<h2><a href="https://standard-for-public-code.github.io/standard-for-public-code/criteria/bundle-policy-and-source-code.html">Bundle policy and source code</a></h2>
+<h2><a href="https://www.standardforpubliccode.org/criteria/bundle-policy-and-source-code.html">Bundle policy and source code</a></h2>
 
 &#9745;<!-- &#9745; --> criterion met.
 
@@ -175,7 +175,7 @@ Continuous integration tests SHOULD validate that the source code and the policy
 
 </table>
 
-<h2><a href="https://standard-for-public-code.github.io/standard-for-public-code/criteria/make-the-codebase-reusable-and-portable.html">Make the codebase reusable and portable</a></h2>
+<h2><a href="https://www.standardforpubliccode.org/criteria/make-the-codebase-reusable-and-portable.html">Make the codebase reusable and portable</a></h2>
 
 &#9744;<!-- &#9745; --> criterion met.
 
@@ -303,7 +303,7 @@ The software SHOULD NOT require services or platforms available from only a sing
 
 </table>
 
-<h2><a href="https://standard-for-public-code.github.io/standard-for-public-code/criteria/welcome-contributors.html">Welcome contributors</a></h2>
+<h2><a href="https://www.standardforpubliccode.org/criteria/welcome-contributors.html">Welcome contributors</a></h2>
 
 &#9745;<!-- &#9745; --> criterion met.
 
@@ -407,7 +407,7 @@ Including a code of conduct for contributors in the codebase is OPTIONAL.
 
 </table>
 
-<h2><a href="https://standard-for-public-code.github.io/standard-for-public-code/criteria/make-contributing-easy.html">Make contributing easy</a></h2>
+<h2><a href="https://www.standardforpubliccode.org/criteria/make-contributing-easy.html">Make contributing easy</a></h2>
 
 &#9745;<!-- &#9745; --> criterion met.
 
@@ -475,7 +475,7 @@ The documentation MUST include instructions for how to report potentially securi
 
 </table>
 
-<h2><a href="https://standard-for-public-code.github.io/standard-for-public-code/criteria/maintain-version-control.html">Maintain version control</a></h2>
+<h2><a href="https://www.standardforpubliccode.org/criteria/maintain-version-control.html">Maintain version control</a></h2>
 
 &#9745;<!-- &#9745; --> criterion met.
 
@@ -579,7 +579,7 @@ It is OPTIONAL for contributors to sign their commits and provide an email addre
 
 </table>
 
-<h2><a href="https://standard-for-public-code.github.io/standard-for-public-code/criteria/require-review-of-contributions.html">Require review of contributions</a></h2>
+<h2><a href="https://www.standardforpubliccode.org/criteria/require-review-of-contributions.html">Require review of contributions</a></h2>
 
 &#9745;<!-- &#9745; --> criterion met.
 
@@ -695,7 +695,7 @@ for larger contributions
 
 </table>
 
-<h2><a href="https://standard-for-public-code.github.io/standard-for-public-code/criteria/document-codebase-objectives.html">Document codebase objectives</a></h2>
+<h2><a href="https://www.standardforpubliccode.org/criteria/document-codebase-objectives.html">Document codebase objectives</a></h2>
 
 &#9745;<!-- &#9745; --> criterion met.
 
@@ -739,7 +739,7 @@ Documenting the objectives of the codebase for the general public is OPTIONAL.
 
 </table>
 
-<h2><a href="https://standard-for-public-code.github.io/standard-for-public-code/criteria/document-the-code.html">Document the code</a></h2>
+<h2><a href="https://www.standardforpubliccode.org/criteria/document-the-code.html">Document the code</a></h2>
 
 &#9745;<!-- &#9745; --> criterion met.
 
@@ -843,7 +843,7 @@ There SHOULD be continuous integration tests for the quality of the documentatio
 
 </table>
 
-<h2><a href="https://standard-for-public-code.github.io/standard-for-public-code/criteria/use-plain-english.htmlx">Use plain English</a></h2>
+<h2><a href="https://www.standardforpubliccode.org/criteria/use-plain-english.htmlx">Use plain English</a></h2>
 
 &#9745;<!-- &#9745; --> criterion met.
 
@@ -947,7 +947,7 @@ We have <a href="https://standard-for-public-code.github.io/community-translatio
 
 </table>
 
-<h2><a href="https://standard-for-public-code.github.io/standard-for-public-code/criteria/use-open-standards.html">Use open standards</a></h2>
+<h2><a href="https://www.standardforpubliccode.org/criteria/use-open-standards.html">Use open standards</a></h2>
 
 &#9745;<!-- &#9745; --> criterion met.
 
@@ -1039,7 +1039,7 @@ Non-open standards that are machine testable SHOULD be preferred over non-open s
 
 </table>
 
-<h2><a href="https://standard-for-public-code.github.io/standard-for-public-code/criteria/use-continuous-integration.html">Use continuous integration</a></h2>
+<h2><a href="https://www.standardforpubliccode.org/criteria/use-continuous-integration.html">Use continuous integration</a></h2>
 
 &#9745;<!-- &#9745; --> criterion met.
 
@@ -1167,7 +1167,7 @@ Testing the software by using examples in the documentation is OPTIONAL.
 
 </table>
 
-<h2><a href="https://standard-for-public-code.github.io/standard-for-public-code/criteria/publish-with-an-open-license.html">Publish with an open license</a></h2>
+<h2><a href="https://www.standardforpubliccode.org/criteria/publish-with-an-open-license.html">Publish with an open license</a></h2>
 
 &#9745;<!-- &#9745; --> criterion met.
 
@@ -1247,7 +1247,7 @@ CC 0
 
 </table>
 
-<h2><a href="https://standard-for-public-code.github.io/standard-for-public-code/criteria/make-the-codebase-findable.html">Make the codebase findable</a></h2>
+<h2><a href="https://www.standardforpubliccode.org/criteria/make-the-codebase-findable.html">Make the codebase findable</a></h2>
 
 &#9745;<!-- &#9745; --> criterion met.
 
@@ -1375,7 +1375,7 @@ Regular presentations at conferences by the community are OPTIONAL.
 
 </table>
 
-<h2><a href="https://standard-for-public-code.github.io/standard-for-public-code/criteria/use-a-coherent-style.html">Use a coherent style</a></h2>
+<h2><a href="https://www.standardforpubliccode.org/criteria/use-a-coherent-style.html">Use a coherent style</a></h2>
 
 &#9745;<!-- &#9745; --> criterion met.
 
@@ -1422,7 +1422,7 @@ maybe some of the Jekyll could apply
 Ok
 </td>
 <td>
-Including expectations for <a href="https://standard-for-public-code.github.io/standard-for-public-code/criteria/use-plain-english.html">understandable English</a> in the style guide is OPTIONAL.
+Including expectations for <a href="https://www.standardforpubliccode.org/criteria/use-plain-english.html">understandable English</a> in the style guide is OPTIONAL.
 </td>
 <td>
 
@@ -1431,7 +1431,7 @@ Including expectations for <a href="https://standard-for-public-code.github.io/s
 
 </table>
 
-<h2><a href="https://standard-for-public-code.github.io/standard-for-public-code/criteria/document-codebase-maturity.html">Document codebase maturity</a></h2>
+<h2><a href="https://www.standardforpubliccode.org/criteria/document-codebase-maturity.html">Document codebase maturity</a></h2>
 
 &#9745;<!-- &#9745; --> criterion met.
 

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -43,7 +43,7 @@ description:
     videos:
       - 'https://www.youtube.com/watch?v=QWt6vB-cipE'
 developmentStatus: beta
-landingURL: 'https://standard-for-public-code.github.io/standard-for-public-code/'
+landingURL: 'https://www.standardforpubliccode.org/'
 legal:
   authorsFile: 'https://raw.githubusercontent.com/standard-for-public-code/standard-for-public-code/master/AUTHORS.md'
   license: CC0-1.0

--- a/script/generate-checklist.sh
+++ b/script/generate-checklist.sh
@@ -67,7 +67,7 @@ for FILE in $CRITERIA_FILES; do
 	CRITERION_TITLE=$(grep '^# [A-Z]' $FILE \
 		| grep --invert-match 'SPDX' \
 		| cut --fields=2- --delimiter=' ')
-	CRITERION_LINK=https://standard-for-public-code.github.io/standard-for-public-code/criteria/${FILE_BASE}.html
+	CRITERION_LINK=https://www.standardforpubliccode.org/criteria/${FILE_BASE}.html
 	cat << EOF >> $TEMPLATE
 
 <h2>&#9744; $CRITERION_TITLE</h2>


### PR DESCRIPTION
We were still seeing links of the form:

https://standard-for-public-code.github.io/standard-for-public-code/

in a few places, this changes them to be of the form:

https://www.standardforpubliccode.org/

via the following:

```
sed -i -e's@standard-for-public-code.github.io/standard-for-public-code@www.standardforpubliccode.org@g' \
  $( git grep -l standard-for-public-code.github.io/standard-for-public-code )
```