### PR TITLE
fix copyright year in generate-checklist.sh

### DIFF
--- a/docs/checklist.html
+++ b/docs/checklist.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
 <!-- SPDX-License-Identifier: CC0-1.0 -->
-<!-- SPDX-FileCopyrightText: 2023-2025 by The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS -->
+<!-- SPDX-FileCopyrightText: 2025 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2023-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS -->
 <head>
 <meta charset="UTF-8">
 <title>Standard for Public Code Checklist</title>

--- a/script/generate-checklist.sh
+++ b/script/generate-checklist.sh
@@ -12,7 +12,7 @@ cat << EOF > $TEMPLATE
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
 <!-- SPDX-License-Identifier: CC0-1.0 -->
-<!-- SPDX-FileCopyrightText: 2023-$THIS_YEAR by The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS -->
+<!-- SPDX-FileCopyrightText: $THIS_YEAR Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2023-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS -->
 <head>
 <meta charset="UTF-8">
 <title>Standard for Public Code Checklist</title>


### PR DESCRIPTION
Fix copyright year oversight in template, as [seen here]( https://github.com/standard-for-public-code/standard-for-public-code/commit/8efbc2b45ede6df2a779534718eefb9ba36463e9#r155979863 ) by @jgroenen.

The date needed to be adjusted both in the file and in the file [header AND in the generator]( https://github.com/standard-for-public-code/standard-for-public-code/pull/1114/files#diff-e6abd0852cc27476fc09d61d9915314ca1de3415574dabbc0fc7f8f68b7fc0e4R3-R15 ) ....

~Seems that 726a7cb2f9d68fe3002e7299fb5e82f69a4960a4 was lost?~