### PR TITLE
Roadmap description adjustment

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -3,12 +3,12 @@
 <!-- SPDX-License-Identifier: CC0-1.0 -->
 <!-- SPDX-FileCopyrightText: 2025 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2022-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS -->
 
-Last updated: 2024-02-19
+Last updated: 2025-04-30
 
-This document intends to shed light on the current development plans of the team.
-Plans change constantly as new information is absorbed by the team.
+This document intends to shed light on the current development plans of the community for the Standard for Public Code.
+Plans change constantly as new information is absorbed.
 
-Codebase stewards review the roadmap monthly as part of our [backlog pruning session](https://about.publiccode.net/activities/standard-maintenance/backlog-pruning.html).
+The [Steering team](../GOVERNANCE.md#steering-team) and community review the roadmap periodically as part of the regular [community calls](https://github.com/standard-for-public-code/standard-for-public-code/discussions/categories/community-calls) and [releasing a new version](./releasing.md#releasing-a-new-version-of-the-standard-for-public-code).
 
 ## Current work
 


### PR DESCRIPTION
The contents of the roadmap were adjust slightly as part of 0.8.1 (see: 0b28d861c30639348d2d5f772182f404aacbe5cc),
however, the description at the top was not adjusted to match the evolution to a comunity centered governance model.

This makes a first step towards reflecting the change in governance.

No roadmap items are changed as a part of this change.

Relates to: #1024