### PR TITLE
Fix typo in URL

### DIFF
--- a/docs/standard-for-public-code.html
+++ b/docs/standard-for-public-code.html
@@ -843,7 +843,7 @@ There SHOULD be continuous integration tests for the quality of the documentatio
 
 </table>
 
-<h2><a href="https://www.standardforpubliccode.org/criteria/use-plain-english.htmlx">Use plain English</a></h2>
+<h2><a href="https://www.standardforpubliccode.org/criteria/use-plain-english.html">Use plain English</a></h2>
 
 &#9745;<!-- &#9745; --> criterion met.
 


### PR DESCRIPTION
In c5261a9b a stray "x" ended up in the file,
possibly when hand-checking the results of the search-and-replace. This removes the bad character.