### PR TITLE
Explicitly declare permissions of workflows to adhere to the principle of least privilege

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -2,6 +2,10 @@
 # SPDX-FileCopyrightText: 2025 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2021-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS
 
 name: local link check
+
+permissions:
+  contents: read
+
 on:
   workflow_dispatch: {}
 #  schedule:

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -2,6 +2,11 @@
 # SPDX-FileCopyrightText: 2025 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2021-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS
 
 name: release-on-tag
+
+permissions:
+  contents: write
+  packages: write
+
 on:
   push:
     tags:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,10 @@
 # SPDX-FileCopyrightText: 2025 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2021-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS
 
 name: Test
+
+permissions:
+  contents: read
+
 on:
   - push
   - pull_request


### PR DESCRIPTION
GitHub security code scanning reported the lack of explicit permissions for these workflows.