### PR TITLE
Fix typo of version number in title

### DIFF
--- a/docs/standard-for-public-code.html
+++ b/docs/standard-for-public-code.html
@@ -4,7 +4,7 @@
 <!-- SPDX-FileCopyrightText: 2025 Standard for Public Code Authors, https://www.standardforpubliccode.org/AUTHORS; 2022-2024 The Foundation for Public Code <info@publiccode.net>, https://www.standardforpubliccode.org/AUTHORS -->
 <head>
 <meta charset="UTF-8">
-<title>The Standard for Public Code's compliance with the criteria and requirements of the Standard for Public Code version 0.8.0</title>
+<title>The Standard for Public Code's compliance with the criteria and requirements of the Standard for Public Code version 0.8.1</title>
 <style>
 html, body {
 font-family: Mulish;


### PR DESCRIPTION
Somehow the title wasn't updated when the rest of the document was.