### PR TITLE
Links to community landing page

### DIFF
--- a/index.md
+++ b/index.md
@@ -35,8 +35,7 @@ Additional context and background can be found in the [foreword](foreword.md).
 
 ## Community calls
 
-We usually have a community call on the last Thursday of the month at 15:00 (CET/CEST).
-The agenda is coordinated on our [discussion board](https://github.com/standard-for-public-code/standard-for-public-code/discussions/categories/community-calls) roughly a week before the call.
+Join our [community calls](https://community.standardforpubliccode.org/) or come say hello on our [discussion board](https://github.com/standard-for-public-code/standard-for-public-code/discussions).
 
 ## Other resources
 


### PR DESCRIPTION
I've removed the time on the index so we don't have multiple places to update in the future. Or perhaps the index/homepage could be the only 1 place we do have duplicate info? 