### PR TITLE
docs: add a list of volunteers who manages code of conduct concerns/violations

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -12,4 +12,8 @@ Be considerate, respectful, and patient.
 
 Strive to be as constructive as possible.
 
-To raise a concern, please email directors@publiccode.net.
+To raise a concern, please email any one of our volunteers:
+
+* Anton Wiklund <antonwiklund91@gmail.com>
+
+If you wish to volunteer, open a PR adding yourself to the list above.


### PR DESCRIPTION
From today's community call on the 2026-01-29, we discussed how to handle Code of conduct concerns, from the meeting notes:

> We tested the platform's reporting feature and decided it is too limited, with no way to capture nuance or add context.
> We decided to have a list of volunteers who can be contacted.